### PR TITLE
Fix display of presenters who don't have names in the presenter list

### DIFF
--- a/frontend/src/app/presenters/page.tsx
+++ b/frontend/src/app/presenters/page.tsx
@@ -11,7 +11,11 @@ const PresentersListPage = async () => {
     return personArray.sort((a, b) => nameSorter(a.lastName, b.lastName));
   });
 
-  const presenterElements = people.map(({ id, ...person }) => {
+  const peopleWithNames = people.filter(
+    (person) => person.firstName && person.lastName
+  );
+
+  const presenterElements = peopleWithNames.map(({ id, ...person }) => {
     return (
       <div className='border p-4 shadow-sm [&_p]:line-clamp-6' key={id}>
         <PersonDisplay


### PR DESCRIPTION
I think these individuals appear when created as copresenters, and then never log in and set a name in their profiles.
Although the number of individuals is small, they sort to the top of the list and it looks terrible.

This PR removes them from the list entirely.