### PR TITLE
Swap from Image to img for presenter images

### DIFF
--- a/frontend/src/Components/PersonDisplay.tsx
+++ b/frontend/src/Components/PersonDisplay.tsx
@@ -29,7 +29,16 @@ export const PersonDisplay: React.FC<
 
   let isDefaultImage = false;
   let imageElem = null;
-  if (typeof props.image !== 'undefined' && props.image !== null) {
+  if (typeof props.image === 'string') {
+    imageElem = (
+      <img
+        src={props.image}
+        alt={`Image of ${props.firstName} ${props.lastName}`}
+        className='object-contain'
+        sizes='(max-width: 899px) 100vw, 30vw'
+      />
+    );
+  } else if (typeof props.image !== 'undefined' && props.image !== null) {
     // Static image file or by URL
     imageElem = (
       <Image
@@ -85,7 +94,7 @@ export const PersonDisplay: React.FC<
           </div>
         </div>
         <div
-          className={`not-prose relative w-full flex-shrink-0 align-middle md:w-[30%] ${imgDispCName} flex flex-row justify-center`}
+          className={`not-prose relative w-full flex-shrink-0 align-middle md:w-[30%] ${imgDispCName} flex flex-row justify-center px-8`}
         >
           {imageElem}
         </div>


### PR DESCRIPTION
Swap presenter images to the html img rather than the Next.js Image component.
This may work around our image optimisation allocation until after we can fix that issue. 
See #66.