### PR TITLE
Fail loudly on a no-op forced conclusion; refresh instead of revalidatePath

### DIFF
--- a/frontend/playwright/review-force-conclusion.spec.ts
+++ b/frontend/playwright/review-force-conclusion.spec.ts
@@ -74,8 +74,44 @@ test.describe('force early conclusion', { tag: '@regression' }, () => {
         .getByRole('button', { name: 'Force accept', exact: true })
         .click();
 
-      // The submission moves to Accepted and the audit line records who forced it.
-      await expect(page.getByText(/Forced accepted by/)).toBeVisible();
+      // The panel only unmounts when the action reports success, and stays up
+      // with the reason when it does not. Asserting that first splits the two
+      // failure modes that otherwise both surface as "audit line never appeared":
+      // a rejected/no-op write leaves the panel up with its error, whereas a page
+      // that never picked up the write closes it and shows nothing new.
+      //
+      // Anchor on the panel heading, not `dialog`: CenteredDialog's root carries
+      // role="dialog" but is `relative` with only `fixed` children, so it has an
+      // empty box and Playwright reports it hidden even while the dialog is on
+      // screen -- expect(dialog).toBeHidden() would pass unconditionally.
+      await expect(
+        page.getByRole('heading', { name: 'Force accept this submission?' })
+      ).toBeHidden();
+
+      // Scope the audit line to THIS submission's card. A page-wide
+      // getByText(/Forced accepted by/) also matches the audit line of any other
+      // forced submission on the page -- including long-lived ones on seeded
+      // presentations that no test tears down -- so it passes even when this
+      // force wrote nothing. Requiring the audit text and this title's heading
+      // inside the same element ties the assertion to the submission under test;
+      // .last() picks the innermost such element (the card column) rather than
+      // the page wrapper, which contains every card.
+      //
+      // Reload before asserting: the write is durable by the time the action
+      // returns, but the page it re-renders in response is not reliably fresh.
+      // Measured locally at ~50% stale over 10 runs, unchanged by revalidatePath,
+      // refresh() or a client-side router.refresh() -- so the immediate update is
+      // a framework-level read-your-writes gap, not something this spec can wait
+      // out (toBeVisible only re-queries the DOM; nothing re-renders it). Assert
+      // the durable outcome here and track the refresh gap separately.
+      await page.reload();
+
+      const forcedCard = page
+        .locator('div')
+        .filter({ has: page.getByRole('heading', { name: title, exact: true }) })
+        .filter({ hasText: /Forced accepted by/ })
+        .last();
+      await expect(forcedCard).toBeVisible();
     });
   });
 

--- a/frontend/src/app/review-submissions/actions.castVote.test.ts
+++ b/frontend/src/app/review-submissions/actions.castVote.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { castVote } from './actions';
 import { createServerClient } from '@/lib/supabaseServer';
-import { revalidatePath } from 'next/cache';
+import { refresh } from 'next/cache';
 
 vi.mock('@/lib/supabaseServer', () => ({
   createServerClient: vi.fn()
 }));
 vi.mock('next/cache', () => ({
-  revalidatePath: vi.fn(),
+  refresh: vi.fn(),
   // castVote reaches getUserDataForMenu, which uses these cache primitives.
   cacheLife: vi.fn(),
   cacheTag: vi.fn()
@@ -93,7 +93,7 @@ describe('castVote', () => {
     buildClient({ userId: null, organizerCount: 0 });
     const res = await castVote('pres-1', 'for');
     expect(res.success).toBe(false);
-    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 
   it('rejects a non-organizer', async () => {
@@ -116,7 +116,7 @@ describe('castVote', () => {
     expect(upsert).not.toHaveBeenCalled();
   });
 
-  it('upserts a vote for an organizer and revalidates', async () => {
+  it('upserts a vote for an organizer and refreshes', async () => {
     const { upsert } = buildClient({ userId: 'u-1', organizerCount: 1 });
     const res = await castVote('pres-1', 'against');
     expect(res.success).toBe(true);
@@ -127,7 +127,7 @@ describe('castVote', () => {
         vote: 'against'
       })
     );
-    expect(revalidatePath).toHaveBeenCalledWith('/review-submissions');
+    expect(refresh).toHaveBeenCalled();
   });
 
   it('deletes the vote row when clearing (vote === null)', async () => {
@@ -136,7 +136,7 @@ describe('castVote', () => {
     expect(res.success).toBe(true);
     expect(del).toHaveBeenCalled();
     expect(upsert).not.toHaveBeenCalled();
-    expect(revalidatePath).toHaveBeenCalledWith('/review-submissions');
+    expect(refresh).toHaveBeenCalled();
   });
 
   it('returns failure when the mutation errors', async () => {
@@ -147,6 +147,6 @@ describe('castVote', () => {
     });
     const res = await castVote('pres-1', 'for');
     expect(res.success).toBe(false);
-    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/review-submissions/actions.forceConclude.test.ts
+++ b/frontend/src/app/review-submissions/actions.forceConclude.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { forceSubmissionOutcome } from './actions';
 import { createServerClient } from '@/lib/supabaseServer';
-import { revalidatePath } from 'next/cache';
+import { refresh } from 'next/cache';
 
 vi.mock('@/lib/supabaseServer', () => ({
   createServerClient: vi.fn()
 }));
 vi.mock('next/cache', () => ({
-  revalidatePath: vi.fn(),
+  refresh: vi.fn(),
   cacheLife: vi.fn(),
   cacheTag: vi.fn()
 }));
@@ -26,9 +26,12 @@ const buildClient = (opts: {
   isOrganizer?: boolean;
   isConcluder?: boolean;
   rpcError?: { message: string; code: string } | null;
+  // The RPC resolves to NULL (no error) when it concluded nothing -- see the
+  // "wrote nothing" case below.
+  rpcWroteNothing?: boolean;
 }) => {
   const rpc = vi.fn().mockResolvedValue({
-    data: opts.rpcError ? null : 'accepted',
+    data: opts.rpcError || opts.rpcWroteNothing ? null : 'accepted',
     error: opts.rpcError ?? null
   });
 
@@ -88,7 +91,7 @@ describe('forceSubmissionOutcome', () => {
     const res = await forceSubmissionOutcome('pres-1', 'accepted');
     expect(res.success).toBe(false);
     expect(rpc).not.toHaveBeenCalled();
-    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 
   it('rejects a non-organizer', async () => {
@@ -109,10 +112,10 @@ describe('forceSubmissionOutcome', () => {
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/not permitted/i);
     expect(rpc).not.toHaveBeenCalled();
-    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 
-  it('calls the RPC and revalidates for an authorized concluder', async () => {
+  it('calls the RPC and refreshes for an authorized concluder', async () => {
     const { rpc } = buildClient({
       userId: 'u-1',
       isOrganizer: true,
@@ -124,7 +127,7 @@ describe('forceSubmissionOutcome', () => {
       v_pid: 'pres-1',
       v_outcome: 'declined'
     });
-    expect(revalidatePath).toHaveBeenCalledWith('/review-submissions');
+    expect(refresh).toHaveBeenCalled();
   });
 
   it('surfaces a friendly message when the submission is already concluded', async () => {
@@ -141,6 +144,25 @@ describe('forceSubmissionOutcome', () => {
     expect(rpc).toHaveBeenCalled();
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/already been concluded/i);
-    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  // force_submission_outcome returns NULL, without raising, when it concluded
+  // nothing -- e.g. a concurrent transaction concluded the submission between
+  // its "already concluded" guard and its INSERT ... ON CONFLICT DO NOTHING.
+  // Reporting success there would claim an outcome that was never written and
+  // has no audit row, so the action must treat it as a failure.
+  it('fails when the RPC reports it wrote nothing', async () => {
+    const { rpc } = buildClient({
+      userId: 'u-1',
+      isOrganizer: true,
+      isConcluder: true,
+      rpcWroteNothing: true
+    });
+    const res = await forceSubmissionOutcome('pres-1', 'accepted');
+    expect(rpc).toHaveBeenCalled();
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not applied/i);
+    expect(refresh).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/review-submissions/actions.ts
+++ b/frontend/src/app/review-submissions/actions.ts
@@ -3,7 +3,7 @@
 import { createServerClient } from '@/lib/supabaseServer';
 import { joinNames, logToDb } from '@/lib/utils';
 import type { OrganizerVote } from '@/lib/databaseModels';
-import { revalidatePath } from 'next/cache';
+import { refresh } from 'next/cache';
 import JSZip from 'jszip';
 import { getUserDataForMenu } from '@/lib/supabase/userFunctions';
 
@@ -90,7 +90,17 @@ export const castVote = async (
     return { success: false, error: 'Could not record your vote.' };
   }
 
-  revalidatePath('/review-submissions');
+  // The review page reads its submissions/votes uncached (createServerClient in
+  // the component), so there is no cache entry to invalidate -- updateTag and
+  // revalidatePath have nothing to act on here. refresh() is the primitive that
+  // matches: ask the client router to re-render after the mutation.
+  //
+  // Caveat: this does not reliably deliver read-your-writes today. The page the
+  // action re-renders comes back stale roughly half the time (measured on the
+  // force path, and unchanged by revalidatePath or a client router.refresh()),
+  // so callers may still need a reload to see their own write. Keeping refresh()
+  // because it is the correct primitive, not because it closes that gap.
+  refresh();
   return { success: true };
 };
 
@@ -147,10 +157,13 @@ export const forceSubmissionOutcome = async (
     };
   }
 
-  const { error } = await supabase.rpc('force_submission_outcome', {
-    v_pid: presentationId,
-    v_outcome: outcome
-  });
+  const { data: written, error } = await supabase.rpc(
+    'force_submission_outcome',
+    {
+      v_pid: presentationId,
+      v_outcome: outcome
+    }
+  );
 
   if (error) {
     await logToDb(
@@ -175,7 +188,31 @@ export const forceSubmissionOutcome = async (
     return { success: false, error: friendly };
   }
 
-  revalidatePath('/review-submissions');
+  // force_submission_outcome only writes the outcome (and the forced_conclusions
+  // audit row) when apply_submission_outcome actually inserted; otherwise it
+  // returns NULL without raising. That happens when the submission was concluded
+  // by a concurrent transaction between this RPC's own "already concluded" guard
+  // and its INSERT ... ON CONFLICT DO NOTHING, or when the submission has since
+  // been deleted. Reporting success there would tell the organizer the outcome
+  // was forced while nothing was written and no audit trail exists, so treat a
+  // NULL return as a failure.
+  if (written === null) {
+    await logToDb(
+      'error',
+      'Force submission outcome wrote nothing',
+      'review-submissions/force',
+      { userId: user.id, context: { presentationId, outcome } }
+    );
+    return {
+      success: false,
+      error:
+        'The outcome was not applied — this submission may have just been concluded elsewhere. Reload the page and check its status.'
+    };
+  }
+
+  // See castVote for why this is refresh() rather than updateTag/revalidatePath,
+  // and for the caveat that the re-render it triggers is not reliably fresh.
+  refresh();
   return { success: true };
 };
 


### PR DESCRIPTION
Fixes the `review-force-conclusion.spec.ts:46` failure seen on PR #131's e2e run, plus two problems in the test that were hiding it.

## 1. A no-op force reported success

`force_submission_outcome` returns `NULL`, without raising, when `apply_submission_outcome` inserted nothing — e.g. when a concurrent transaction concluded the submission between the RPC's own "already concluded" guard and its `INSERT ... ON CONFLICT DO NOTHING`. `forceSubmissionOutcome` only inspected `error`, so that case told the organizer the outcome was forced while no outcome row and no `forced_conclusions` audit row existed.

Now the returned value is checked, logged to `log`, and surfaced as an error in the dialog.

## 2. `revalidatePath` → `refresh`

The review page reads its submissions with `createServerClient()` in the component — uncached. `revalidatePath` had no cache entry to act on, and `updateTag` doesn't fit either (nothing is `cacheTag`'d). `refresh()` is the primitive that matches a mutation on uncached data.

**This does not close the read-your-writes gap.** The page the action re-renders comes back stale ~50% of the time locally (10 repeats), unchanged by `revalidatePath`, `refresh()`, or a client-side `router.refresh()`. That looks like a framework-level issue worth tracking separately — organizers may need to reload to see their own forced outcome.

## 3. Test fixes

- **The audit-line assertion was page-wide.** `getByText(/Forced accepted by/)` matched *any* forced submission on the page, including long-lived ones on seeded presentations that no test tears down. It passed even when the force under test wrote nothing — which is why this reproduced in CI (whose TEST project has no such row) but never locally. Now scoped to the card under test.
- **It asserted without a reload**, which the refresh gap makes unreliable. It now reloads and asserts the durable outcome.
- A panel-heading assertion separates "write rejected" from "page stale". `expect(getByRole('dialog')).toBeHidden()` cannot do this: `CenteredDialog`'s root is `relative` with only `fixed` children, so it has an empty box and always reads as hidden.

## Verification

- Force spec: 10/10 repeats green (was 5/10 before the reload).
- Negative control: stubbing `apply_submission_outcome` to return `NULL` makes the test fail at the panel-heading assertion, with the new error visible in the dialog.
- Full unit suite (216) and full Playwright suite green, except two pre-existing `og-metadata` failures caused by serving on a non-3000 port (metadata is pinned to `localhost:3000`).

Note: env vars were ruled out as a cause — the test ran rather than skipping, the concluder logged in, and the force buttons rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)