### PR TITLE
Improve handling of login attempts with non-registered emails.

### DIFF
--- a/frontend/playwright/user-login.spec.ts
+++ b/frontend/playwright/user-login.spec.ts
@@ -166,6 +166,43 @@ test.describe('User Authentication Tests', () => {
     await expect(userButton).toBeVisible();
   });
 
+  test('Sign-in with an unregistered address offers registration', async ({
+    page
+  }) => {
+    // No user is created for this address: this is the failure that fills the
+    // logs, and the response must not reveal that the account is missing.
+    const email = generateTestEmail('unregistered');
+
+    await page.goto('/auth/login?redirectTo=/ticket');
+    const loginForm = page.getByRole('form', { name: 'Login Form' });
+    await loginForm.getByLabel('Email').fill(email);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    const formError = loginForm.getByRole('alert');
+    await expect(formError).toContainText(/couldn't send a login code/i);
+    await expect(page).toHaveURL(/\/auth\/login/);
+
+    // The typed address (and redirectTo) survive the switch to registration.
+    await formError.getByRole('link', { name: /Create an account/i }).click();
+    await expect(
+      page.getByRole('form', { name: 'Registration Form' }).getByLabel('Email')
+    ).toHaveValue(email);
+    await expect(page).toHaveURL(/redirectTo=%2Fticket/);
+
+    // Recorded as 'info' under its own source, so 'error' rows stay meaningful.
+    const { data } = await supabaseAdmin
+      .from('log')
+      .select('severity,context')
+      .eq('source', 'auth/signin-no-account')
+      .order('created_at', { ascending: false })
+      .limit(10);
+
+    const row = data?.find(
+      (entry) => (entry.context as { email?: string } | null)?.email === email
+    );
+    expect(row?.severity).toBe('info');
+  });
+
   test('Repeated clicking only sends one email - login', async ({ page }) => {
     // Setup a user for login tests
     const user = generateUser('FastClicking', 'User');

--- a/frontend/src/Components/SigninRegistration/SignInUpActions.ts
+++ b/frontend/src/Components/SigninRegistration/SignInUpActions.ts
@@ -11,6 +11,7 @@ import {
   loginStateFromFormData,
   RegistrationSchema,
   registrationStateFromFormData,
+  SIGN_IN_FAILED_MESSAGE,
   verificationRequestFromFormData
 } from './formState';
 import { blockIfEmailIsDisallowed, blockIfProfileIsFlagged } from './validation';
@@ -68,13 +69,17 @@ export const signInFromFormWithRedirect = async (
   const { email, redirectTo } = validatedFields.data;
   blockIfEmailIsDisallowed(email);
 
-  const signInSuccessful = await signIn(email, redirectTo);
-  
-  if (signInSuccessful) {
+  const outcome = await signIn(email, redirectTo);
+
+  if (outcome === 'sent') {
     const redirectUrl = buildValidateLoginUrl(email, redirectTo);
     redirect(redirectUrl, RedirectType.push);
   }
 
+  // 'no-account' and 'failed' deliberately share a message: a distinct one for
+  // the former would let anyone test whether an address is registered here.
+  // The form pairs this with a link to registration, which covers the (far more
+  // common) case without disclosing anything.
   return {
     data:
       previousState.data.email === submittedState.data.email &&
@@ -82,7 +87,7 @@ export const signInFromFormWithRedirect = async (
         ? previousState.data
         : submittedState.data,
     errors: {
-      form: 'Could not send a login code. Please try again.'
+      form: SIGN_IN_FAILED_MESSAGE
     }
   };
 };

--- a/frontend/src/Components/SigninRegistration/authService.ts
+++ b/frontend/src/Components/SigninRegistration/authService.ts
@@ -25,10 +25,24 @@ export const verifyLogin = async (data: {
   return verifyData.user !== null;
 };
 
+/**
+ * 'sent'       – an OTP email is on its way.
+ * 'no-account' – the address has no account. An ordinary user mistake (typo,
+ *                never registered, registered under a different address), so
+ *                it is recorded at 'info' rather than 'error'.
+ * 'failed'     – something on our side went wrong (link generation or mail
+ *                delivery). These are the entries worth alerting on.
+ *
+ * The caller must render the same message for the last two: telling a visitor
+ * that an address has no account turns sign-in into an account-existence
+ * oracle.
+ */
+export type SignInOutcome = 'sent' | 'no-account' | 'failed';
+
 export const signIn = async (
   email: string,
   redirectTo?: string
-): Promise<boolean> => {
+): Promise<SignInOutcome> => {
   try {
     const response = await generateSupabaseLinks({
       type: 'magiclink',
@@ -36,20 +50,37 @@ export const signIn = async (
       redirectTo
     });
 
-    const { properties, user } = response.data;
-    if (properties == null) {
+    if (response.reason === 'user-not-found') {
       await logToDb(
-        'error',
-        'No OTP properties returned during sign-in',
-        'auth/signin',
+        'info',
+        'Sign-in attempted for an address with no account',
+        'auth/signin-no-account',
         {
           context: { email },
           retainDays: 14
         }
       );
-      return false;
+      return 'no-account';
     }
 
+    if (response.reason !== null) {
+      await logToDb(
+        'error',
+        'No OTP properties returned during sign-in',
+        'auth/signin',
+        {
+          context: {
+            email,
+            error: response.error.message,
+            status: response.error.status ?? null
+          },
+          retainDays: 90
+        }
+      );
+      return 'failed';
+    }
+
+    const { properties, user } = response.data;
     const { firstName, lastName } = parseUserMetadata(user.user_metadata);
     const plainText = otpEmailText(firstName, lastName, properties.email_otp);
     const mailResult = await sendMailApi({
@@ -63,13 +94,24 @@ export const signIn = async (
       )
     });
 
-    return mailResult.status === 200;
+    if (mailResult.status !== 200) {
+      await logToDb('error', 'Sign-in OTP email was rejected', 'auth/signin', {
+        context: { email, status: mailResult.status },
+        retainDays: 90
+      });
+      return 'failed';
+    }
+
+    return 'sent';
   } catch (err) {
     await logToDb('error', 'Failed to send sign-in link', 'auth/signin', {
-      context: { message: err instanceof Error ? err.message : String(err) },
+      context: {
+        email,
+        message: err instanceof Error ? err.message : String(err)
+      },
       retainDays: 90 // Possibly indicates an issue with email delivery, but unlikely to need forever.
     });
-    return false;
+    return 'failed';
   }
 };
 

--- a/frontend/src/Components/SigninRegistration/formState.ts
+++ b/frontend/src/Components/SigninRegistration/formState.ts
@@ -83,6 +83,35 @@ export const registrationStateFromFormData = (formData: FormData): RegistrationS
   }
 });
 
+// Shown for every unsuccessful sign-in, whether the address is unregistered or
+// the send genuinely failed — see the comment in SignInUpActions. It names the
+// two things a visitor can act on rather than telling them to "try again",
+// which only produced repeat submissions of the same wrong address.
+export const SIGN_IN_FAILED_MESSAGE =
+  "We couldn't send a login code to that address. Check it for typos, or " +
+  'register if you have not used this site before.';
+
+/**
+ * Links between the sign-in and registration forms carry the address already
+ * typed (and any redirectTo), so switching forms never means retyping — a
+ * retype is where the second typo comes from.
+ */
+export const buildAuthFormUrl = (
+  path: '/auth/login' | '/auth/register',
+  options?: { email?: string; redirectTo?: string }
+): string => {
+  const params = new URLSearchParams();
+  if (options?.email) {
+    params.append('email', options.email);
+  }
+  if (options?.redirectTo) {
+    params.append('redirectTo', options.redirectTo);
+  }
+
+  const query = params.toString();
+  return query.length > 0 ? `${path}?${query}` : path;
+};
+
 export const buildValidateLoginUrl = (email: string, redirectTo?: string): string => {
   const params = new URLSearchParams({ email });
   if (redirectTo) {

--- a/frontend/src/app/auth/LoginForm.test.tsx
+++ b/frontend/src/app/auth/LoginForm.test.tsx
@@ -2,7 +2,10 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LoginForm } from './LoginForm';
-import { LoginSchema } from '@/Components/SigninRegistration/formState';
+import {
+  buildAuthFormUrl,
+  LoginSchema
+} from '@/Components/SigninRegistration/formState';
 
 vi.mock('@/Components/SigninRegistration/SignInUpActions', () => ({
   signInFromFormWithRedirect: vi.fn()
@@ -23,6 +26,60 @@ describe('LoginSchema email normalisation', () => {
     if (result.success) {
       expect(result.data.email).toBe('user@example.com');
     }
+  });
+});
+
+describe('buildAuthFormUrl', () => {
+  it('omits the query string entirely when nothing is carried over', () => {
+    expect(buildAuthFormUrl('/auth/register')).toBe('/auth/register');
+    expect(buildAuthFormUrl('/auth/register', { email: '' })).toBe(
+      '/auth/register'
+    );
+  });
+
+  it('encodes the carried email and redirectTo', () => {
+    expect(
+      buildAuthFormUrl('/auth/login', {
+        email: 'a+b@example.com',
+        redirectTo: '/ticket'
+      })
+    ).toBe('/auth/login?email=a%2Bb%40example.com&redirectTo=%2Fticket');
+  });
+});
+
+describe('LoginForm cross-links', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('prefills an email carried over from the registration form', () => {
+    render(<LoginForm email='carried@example.com' />);
+
+    expect(screen.getByRole('textbox', { name: /email/i })).toHaveProperty(
+      'value',
+      'carried@example.com'
+    );
+  });
+
+  it('carries the typed email and redirectTo to the registration form', async () => {
+    render(<LoginForm redirectTo='/ticket' />);
+
+    const joinLink = screen.getByRole('link', { name: /Join Now/i });
+    expect(joinLink.getAttribute('href')).toBe(
+      '/auth/register?redirectTo=%2Fticket'
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /email/i }),
+      'typed@example.com'
+    );
+
+    await waitFor(() => {
+      expect(joinLink.getAttribute('href')).toBe(
+        '/auth/register?email=typed%40example.com&redirectTo=%2Fticket'
+      );
+    });
   });
 });
 

--- a/frontend/src/app/auth/LoginForm.tsx
+++ b/frontend/src/app/auth/LoginForm.tsx
@@ -6,13 +6,14 @@ import {
   LoginState,
   signInFromFormWithRedirect
 } from '@/Components/SigninRegistration/SignInUpActions';
+import { buildAuthFormUrl } from '@/Components/SigninRegistration/formState';
 import { useFormValidation } from '@/Components/Utilities/useFormValidation';
 import { useTouchedFieldErrors } from '@/Components/Utilities/useTouchedFieldErrors';
 import Link from 'next/link';
-import { useActionState } from 'react';
+import { useActionState, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
-const FormError = (props: { message?: string }) => {
+const FormError = (props: { message?: string; registerPath: string }) => {
   const { pending } = useFormStatus();
 
   if (pending || props.message === undefined) {
@@ -20,20 +21,25 @@ const FormError = (props: { message?: string }) => {
   }
 
   return (
-    <p className='pt-2 text-center text-base text-red-700' role='alert'>
-      {props.message}
-    </p>
+    <div className='pt-2 text-center text-base text-red-700' role='alert'>
+      <p>{props.message}</p>
+      {/* The error is the moment a visitor discovers they may be in the wrong
+          place, so the route out is offered here rather than only at the top of
+          the page. */}
+      <p className='pt-1'>
+        <Link className='link' href={props.registerPath} replace scroll={false}>
+          Create an account
+        </Link>
+      </p>
+    </div>
   );
 };
 
-export const LoginForm = (props: { redirectTo?: string }) => {
-  const registerPath = props.redirectTo
-    ? `/auth/register?redirectTo=${props.redirectTo}`
-    : '/auth/register';
+export const LoginForm = (props: { redirectTo?: string; email?: string }) => {
   const initialState: LoginState = {
     errors: undefined,
     data: {
-      email: '',
+      email: props.email ?? '',
       redirectTo: props.redirectTo
     }
   };
@@ -45,6 +51,13 @@ export const LoginForm = (props: { redirectTo?: string }) => {
   const { getFieldError, onBlurFor } = useTouchedFieldErrors<'email'>({
     validationMessages,
     fieldErrors: state.errors
+  });
+  // Mirrors the (uncontrolled) email input so the links across to registration
+  // can carry whatever has been typed so far.
+  const [typedEmail, setTypedEmail] = useState(state.data.email);
+  const registerPath = buildAuthFormUrl('/auth/register', {
+    email: typedEmail.trim(),
+    redirectTo: props.redirectTo
   });
 
   return (
@@ -74,6 +87,9 @@ export const LoginForm = (props: { redirectTo?: string }) => {
         action={formAction}
         onChange={(ev) => {
           if (ev.target instanceof HTMLInputElement) {
+            if (ev.target.name === 'email') {
+              setTypedEmail(ev.target.value);
+            }
             checkValidity(ev.target);
           }
         }}
@@ -104,7 +120,7 @@ export const LoginForm = (props: { redirectTo?: string }) => {
           staticText='Log In'
           pendingText='Logging In...'
         />
-        <FormError message={state.errors?.form} />
+        <FormError message={state.errors?.form} registerPath={registerPath} />
       </form>
       {/* </div> */}
     </div>

--- a/frontend/src/app/auth/RegistrationForm.test.tsx
+++ b/frontend/src/app/auth/RegistrationForm.test.tsx
@@ -34,6 +34,40 @@ describe('RegistrationSchema email normalisation', () => {
   });
 });
 
+describe('RegistrationForm cross-links', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('prefills an email carried over from the sign-in form', () => {
+    render(<RegistrationForm email='carried@example.com' />);
+
+    expect(screen.getByRole('textbox', { name: /email/i })).toHaveProperty(
+      'value',
+      'carried@example.com'
+    );
+  });
+
+  it('carries the typed email back to the sign-in form', async () => {
+    render(<RegistrationForm />);
+
+    const signInLink = screen.getByRole('link', { name: /Sign In/i });
+    expect(signInLink.getAttribute('href')).toBe('/auth/login');
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /email/i }),
+      'typed@example.com'
+    );
+
+    await waitFor(() => {
+      expect(signInLink.getAttribute('href')).toBe(
+        '/auth/login?email=typed%40example.com'
+      );
+    });
+  });
+});
+
 describe('RegistrationForm error rendering', () => {
   afterEach(() => {
     cleanup();

--- a/frontend/src/app/auth/RegistrationForm.tsx
+++ b/frontend/src/app/auth/RegistrationForm.tsx
@@ -6,10 +6,11 @@ import {
   registerFromFormWithRedirect,
   RegistrationState
 } from '@/Components/SigninRegistration/SignInUpActions';
+import { buildAuthFormUrl } from '@/Components/SigninRegistration/formState';
 import { useFormValidation } from '@/Components/Utilities/useFormValidation';
 import { useTouchedFieldErrors } from '@/Components/Utilities/useTouchedFieldErrors';
 import Link from 'next/link';
-import { useActionState } from 'react';
+import { useActionState, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 const FormError = (props: { message?: string }) => {
@@ -26,16 +27,16 @@ const FormError = (props: { message?: string }) => {
   );
 };
 
-export const RegistrationForm = (props: { redirectTo?: string }) => {
-  const loginPath = props.redirectTo
-    ? `/auth/login?redirectTo=${props.redirectTo}`
-    : '/auth/login';
+export const RegistrationForm = (props: {
+  redirectTo?: string;
+  email?: string;
+}) => {
   const initialState: RegistrationState = {
     errors: undefined,
     data: {
       firstName: '',
       lastName: '',
-      email: '',
+      email: props.email ?? '',
       redirectTo: props.redirectTo
     }
   };
@@ -50,6 +51,13 @@ export const RegistrationForm = (props: { redirectTo?: string }) => {
       fieldErrors: state.errors
     }
   );
+  // Mirrors the (uncontrolled) email input so the link back to sign-in can
+  // carry whatever has been typed so far.
+  const [typedEmail, setTypedEmail] = useState(state.data.email);
+  const loginPath = buildAuthFormUrl('/auth/login', {
+    email: typedEmail.trim(),
+    redirectTo: props.redirectTo
+  });
 
   return (
     <div className='mx-auto flex max-w-lg flex-col py-4'>
@@ -96,6 +104,9 @@ export const RegistrationForm = (props: { redirectTo?: string }) => {
         action={formAction}
         onChange={(ev) => {
           if (ev.target instanceof HTMLInputElement) {
+            if (ev.target.name === 'email') {
+              setTypedEmail(ev.target.value);
+            }
             checkValidity(ev.target);
           }
         }}

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -41,7 +41,13 @@ const LoginPageContent = async ({
     redirect(redirectTo ?? '/');
   }
 
-  return <LoginForm redirectTo={redirectTo} />;
+  // Carried over from the registration form so switching back never means
+  // retyping the address.
+  const emailParam = (await searchParams)?.email;
+  const email =
+    typeof emailParam === 'string' ? decodeURI(emailParam) : undefined;
+
+  return <LoginForm redirectTo={redirectTo} email={email} />;
 };
 
 export default LoginPage;

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -41,7 +41,13 @@ const RegistrationPageContent = async ({
     redirect(redirectTo ?? '/');
   }
 
-  return <RegistrationForm redirectTo={redirectTo} />;
+  // Carried over from the sign-in form so switching across never means
+  // retyping the address.
+  const emailParam = (await searchParams)?.email;
+  const email =
+    typeof emailParam === 'string' ? decodeURI(emailParam) : undefined;
+
+  return <RegistrationForm redirectTo={redirectTo} email={email} />;
 };
 
 export default RegistrationPage;

--- a/frontend/src/lib/generateSupabaseLinks.ts
+++ b/frontend/src/lib/generateSupabaseLinks.ts
@@ -29,16 +29,23 @@ export type GenerateLinkBody =
       redirectTo?: string;
     };
 
+// `reason` lets callers separate the ordinary "that address has no account"
+// case (a user mistake) from an actual GoTrue/API failure, which otherwise look
+// identical from the outside — both just yield null properties.
+export type GenerateLinkFailureReason = 'user-not-found' | 'api-error';
+
 export type GenerateLinkReturn =
   | {
       data: { user: User; properties: GenerateLinkProperties };
       linkType: LinkType;
       error: null;
+      reason: null;
     }
   | {
       data: { user: null; properties: null };
       linkType: null;
       error: ApiError | AuthError;
+      reason: GenerateLinkFailureReason;
     };
 
 export type LinkType = 'signup' | 'magiclink' | 'invite' | 'recovery';
@@ -90,7 +97,8 @@ export const generateSupabaseLinks = async (
         return {
           data: { user: null, properties: null },
           linkType: null,
-          error: { message: 'User not found', status: 401 }
+          error: { message: 'User not found', status: 401 },
+          reason: 'user-not-found'
         };
       }
       fnPromise = createAdminClient().auth.admin.generateLink({
@@ -140,7 +148,7 @@ const handleApiResponse = (
   const { data, error } = value;
   // console.log({data, error})
   if (error) {
-    return { data, linkType: null, error };
+    return { data, linkType: null, error, reason: 'api-error' };
   }
-  return { data, linkType: type, error };
+  return { data, linkType: type, error, reason: null };
 };


### PR DESCRIPTION
This has particularly been triggered by emerson emails (replacing ni.com emails).
Add tests to cover different mechanisms of failure during login and their responses.
Add a better message when logging in, and provide a more prominent link to create a new account.

This is ideally a prequel to better options to manage email addresses, but that will require much more effort to change, so merging this now to get immediate improvements.